### PR TITLE
Update gtfs2lc-clean.sh with portable shebang

### DIFF
--- a/bin/gtfs2lc-clean.sh
+++ b/bin/gtfs2lc-clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
I use NixOS with Fish as my shell, which means this script fails, because it won't find `bash`. I therefore propose to use the portable shebang as a general solution.

Pros: Works for me

Cons: Might break old systems that don't have `env`. Also doesn't allow to pass arguments to the interpreter, but I don't believe that this is the case here.

Relevant discussions:

- https://unix.stackexchange.com/questions/632053/how-to-get-bin-bash-on-nixos
- https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my